### PR TITLE
feat(items): render item descriptions as HTML with marked

### DIFF
--- a/src/components/items/ItemCard.astro
+++ b/src/components/items/ItemCard.astro
@@ -2,6 +2,7 @@
 import { Plus, Check } from "@lucide/astro";
 import { getItemDescription } from "../../utils/items-loader";
 import Stone from "@assets/img/小石.svg";
+import { marked } from "marked";
 
 const { t, card, selectedCategory = "all" } = Astro.props;
 
@@ -82,9 +83,7 @@ const totalRemaining = hasSubItems
 				</span>
 			</button>
 		</div>
-		<div class="description">
-			{currentDescription}
-		</div>
+		<div class="description" set:html={marked.parse(currentDescription)} />
 	</div>
 </div>
 


### PR DESCRIPTION
Simple fix for #116.
Anyway, this makes some texts bold in the preview card, which made it kind of unbalanced. Perhaps ignoring markdown syntaxes on the ItemCard will be better?